### PR TITLE
Universal device support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+./build
+.cache

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+# Wrapper for meson and ninja
+
+.PHONY: all install uninstall run clean meson
+
+all: meson
+	cd build && ninja
+
+install: meson
+	cd build && ninja install
+
+uninstall:
+	@rm -f "/usr/local/bin/iio-hyprland" || echo "Error: permission denied (try running with sudo)"
+
+run: all
+	build/iio-hyprland
+
+clean:
+	rm -rf build
+
+meson:
+	meson build

--- a/README.md
+++ b/README.md
@@ -20,13 +20,14 @@ git clone https://github.com/JeanSchoeller/iio-hyprland
 
 cd iio-hyprland
 
-mkdir build
+sudo make install
+```
 
-meson build
+## Uninstalling 
+```
+cd iio-hyprland
 
-cd build
-
-ninja install
+sudo make uninstall
 ```
 
 ## Running

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # iio-hyprland
-Fork of a fork of okeri/iio-sway for Hyprland
-
-**This fork rotates all Tablets and Touch Devices without the need to add them manually.**
+A fork of okeri/iio-sway for Hyprland
 
 Listens to iio-sensor-proxy and automatically changes Hyprland output orientation
 
@@ -9,17 +7,24 @@ Listens to iio-sensor-proxy and automatically changes Hyprland output orientatio
 
 :warning: Make sure [iio-sensor-proxy](https://gitlab.freedesktop.org/hadess/iio-sensor-proxy/) running :warning:
 
+### Arch linux
+
+`yay iio-hyprland-git`
+
+`paru iio-hyprland-git`
+
+
 ### Build from scratch
 
 ```
-git clone https://github.com/Desktop31/iio-hyprland
+git clone https://github.com/JeanSchoeller/iio-hyprland
 
 cd iio-hyprland
 
 sudo make install
 ```
 
-## Uninstalling 
+#### Uninstalling 
 ```
 cd iio-hyprland
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # iio-hyprland
-A fork of okeri/iio-sway for Hyprland
+Fork of a fork of okeri/iio-sway for Hyprland
+
+**This fork rotates all Tablets and Touch Devices without the need to add them manually.**
 
 Listens to iio-sensor-proxy and automatically changes Hyprland output orientation
 
@@ -7,16 +9,10 @@ Listens to iio-sensor-proxy and automatically changes Hyprland output orientatio
 
 :warning: Make sure [iio-sensor-proxy](https://gitlab.freedesktop.org/hadess/iio-sensor-proxy/) running :warning:
 
-### Arch linux
-
-`yay iio-hyprland-git`
-
-`paru iio-hyprland-git`
-
 ### Build from scratch
 
 ```
-git clone https://github.com/JeanSchoeller/iio-hyprland
+git clone https://github.com/Desktop31/iio-hyprland
 
 cd iio-hyprland
 
@@ -33,14 +29,8 @@ sudo make uninstall
 ## Running
 `iio-hyprland [monitor to rotate, default=eDP-1]`, run `hyprctl monitors` to list available outputs.
 
-Add `exec iio-hyprland` to `~/.config/hypr/hyprland.conf`
+Add `exec-once = iio-hyprland` to `~/.config/hypr/hyprland.conf`
 
 ## Touch rotation support
 
-Please open an issue and list the touch devices of your specifications using `hyprctl devices`. The following list should refer to the device working:
-
-* Surface Pro
-* Lenovo Yoga
-* Zenbook
-* HP x360 EliteBook G9
-* Lenovo X1 Yoga Touch
+Should automatically rotate all Tablets and Touch Devices from `hyprctl devices`.

--- a/main.c
+++ b/main.c
@@ -5,25 +5,12 @@
 #include <string.h>
 #include <unistd.h>
 #include <dbus/dbus.h>
-
-enum Orientation { Undefined, Normal, RightUp, LeftUp, BottomUp };
+    
+// corresponds to hyprctl orientation integers
+enum Orientation { Normal, LeftUp, BottomUp, RightUp, Undefined};
 
 DBusError error;
-char* output = "eDP-1";
-char* touch_yoga = "wacom-hid-517f-finger";
-char* pen_yoga = "wacom-hid-517f-pen";
-char* touch_surface = "ipts-touch";
-char* pen_surface = "ipts-stylus";
-char* touch_zenbook = "elan9008:00-04f3:2bb3";
-char* pen_zenbook = "elan9008:00-04f3:2bb3-stylus";
-char* touch_elitebook1040 = "wacom-hid-49f7-finger";
-char* pen_elitebook1040 = "wacom-hid-49f7-pen";
-char* pen_x1_yoga = "wacom-hid-52b5-pen";
-char* touch_x1_yoga = "wacom-hid-52b5-finger";
-char* pen_yoga_6 = "wacom-hid-52fb-pen";
-char* touch_yoga_6 = "wacom-hid-52fb-finger";
-char* touch_surface_go_2 = "elan9038:00-04f3:2a1c";
-char* pen_surface_go_2 = "elan9038:00-04f3:2a1c-stylus";
+char* output = "eDP-1"; // Default output device
 
 void dbus_disconnect(DBusConnection* connection) {
     dbus_connection_flush(connection);
@@ -88,7 +75,7 @@ enum Orientation parse_orientation_signal(DBusMessage* msg) {
 }
 
 void system_fmt(char* format, ...) {
-    char command[128];
+    char command[420];
     va_list args;
     va_start(args, format);
     vsnprintf(command, sizeof(command), format, args);
@@ -97,82 +84,18 @@ void system_fmt(char* format, ...) {
 }
 
 void handle_orientation(enum Orientation orientation) {
-    switch (orientation) {
-        case Normal:
-            system_fmt("hyprctl keyword monitor %s,transform,0", output);
-            system_fmt("hyprctl keyword device:%s:transform 0", touch_yoga);
-            system_fmt("hyprctl keyword device:%s:transform 0", pen_yoga);
-            system_fmt("hyprctl keyword device:%s:transform 0", touch_surface);
-            system_fmt("hyprctl keyword device:%s:transform 0", pen_surface);
-            system_fmt("hyprctl keyword device:%s:transform 0", touch_zenbook);
-            system_fmt("hyprctl keyword device:%s:transform 0", pen_zenbook);
-            system_fmt("hyprctl keyword device:%s:transform 0", touch_elitebook1040);
-            system_fmt("hyprctl keyword device:%s:transform 0", pen_elitebook1040);
-            system_fmt("hyprctl keyword device:%s:transform 0", touch_x1_yoga);
-            system_fmt("hyprctl keyword device:%s:transform 0", pen_x1_yoga);
-            system_fmt("hyprctl keyword device:%s:transform 0", touch_yoga_6);
-            system_fmt("hyprctl keyword device:%s:transform 0", pen_yoga_6);
-            system_fmt("hyprctl keyword device:%s:transform 0", touch_surface_go_2);
-            system_fmt("hyprctl keyword device:%s:transform 0", pen_surface_go_2);
-            break;
+    if (orientation == Undefined)
+        return;
 
-        case BottomUp:
-            system_fmt("hyprctl keyword monitor %s,transform,2", output);
-            system_fmt("hyprctl keyword device:%s:transform 2", touch_yoga);
-            system_fmt("hyprctl keyword device:%s:transform 2", pen_yoga);
-            system_fmt("hyprctl keyword device:%s:transform 2", touch_surface);
-            system_fmt("hyprctl keyword device:%s:transform 2", pen_surface);
-            system_fmt("hyprctl keyword device:%s:transform 2", touch_zenbook);
-            system_fmt("hyprctl keyword device:%s:transform 2", pen_zenbook);
-            system_fmt("hyprctl keyword device:%s:transform 2", touch_elitebook1040);
-            system_fmt("hyprctl keyword device:%s:transform 2", pen_elitebook1040);
-            system_fmt("hyprctl keyword device:%s:transform 2", touch_x1_yoga);
-            system_fmt("hyprctl keyword device:%s:transform 2", pen_x1_yoga);
-            system_fmt("hyprctl keyword device:%s:transform 2", touch_yoga_6);
-            system_fmt("hyprctl keyword device:%s:transform 2", pen_yoga_6);
-            system_fmt("hyprctl keyword device:%s:transform 2", touch_surface_go_2);
-            system_fmt("hyprctl keyword device:%s:transform 2", pen_surface_go_2);
-            break;
+    // transform display
+    system_fmt("hyprctl keyword monitor %s,transform,%d", output, orientation);
 
-        case LeftUp:
-            system_fmt("hyprctl keyword monitor %s,transform,1", output);
-            system_fmt("hyprctl keyword device:%s:transform 1", touch_yoga);
-            system_fmt("hyprctl keyword device:%s:transform 1", pen_yoga);
-            system_fmt("hyprctl keyword device:%s:transform 1", touch_surface);
-            system_fmt("hyprctl keyword device:%s:transform 1", pen_surface);
-            system_fmt("hyprctl keyword device:%s:transform 1", touch_zenbook);
-            system_fmt("hyprctl keyword device:%s:transform 1", pen_zenbook);
-            system_fmt("hyprctl keyword device:%s:transform 1", touch_elitebook1040);
-            system_fmt("hyprctl keyword device:%s:transform 1", pen_elitebook1040);
-            system_fmt("hyprctl keyword device:%s:transform 1", touch_x1_yoga);
-            system_fmt("hyprctl keyword device:%s:transform 1", pen_x1_yoga);
-            system_fmt("hyprctl keyword device:%s:transform 1", touch_yoga_6);
-            system_fmt("hyprctl keyword device:%s:transform 1", pen_yoga_6);
-            system_fmt("hyprctl keyword device:%s:transform 1", touch_surface_go_2);
-            system_fmt("hyprctl keyword device:%s:transform 1", pen_surface_go_2);
-            break;
-
-        case RightUp:
-            system_fmt("hyprctl keyword monitor %s,transform,3", output);
-            system_fmt("hyprctl keyword device:%s:transform 3", touch_yoga);
-            system_fmt("hyprctl keyword device:%s:transform 3", pen_yoga);
-            system_fmt("hyprctl keyword device:%s:transform 3", touch_surface);
-            system_fmt("hyprctl keyword device:%s:transform 3", pen_surface);
-            system_fmt("hyprctl keyword device:%s:transform 3", touch_zenbook);
-            system_fmt("hyprctl keyword device:%s:transform 3", pen_zenbook);
-            system_fmt("hyprctl keyword device:%s:transform 3", touch_elitebook1040);
-            system_fmt("hyprctl keyword device:%s:transform 3", pen_elitebook1040);
-            system_fmt("hyprctl keyword device:%s:transform 3", touch_x1_yoga);
-            system_fmt("hyprctl keyword device:%s:transform 3", pen_x1_yoga);
-            system_fmt("hyprctl keyword device:%s:transform 3", touch_yoga_6);
-            system_fmt("hyprctl keyword device:%s:transform 3", pen_yoga_6);
-            system_fmt("hyprctl keyword device:%s:transform 3", touch_surface_go_2);
-            system_fmt("hyprctl keyword device:%s:transform 3", pen_surface_go_2);
-            break;
-
-        default:
-            break;
-    }
+    // transform touch devices
+    // (and pray that our lord and savior vaxry won't change hyprctl output)
+    system_fmt("while IFS=$'\n' read -r device ; do "
+            "hyprctl keyword device:\"$device\":transform %d; "
+            "done <<< \"$(hyprctl devices | awk '/Touch Device at|Tablet at/ {getline;print $1}')\"",
+            orientation);
 }
 
 DBusMessage* request_orientation(DBusConnection* conn) {


### PR DESCRIPTION
Implemented (hopefully) universal device support by using a shell command that applies rotation to Tablet and Touch Devices found in `hyprctl devices`.

Added Makefile for easier installation (I need `make install` target for my arch autoinstall script).

And updated README.md to reflect these changes + some other tweaks (described in commits).

Tested on Lenovo Yoga 7i (82BH Yoga 7 14ITL5)