### PR TITLE
Fix unnecessary tablet rotation

### DIFF
--- a/main.c
+++ b/main.c
@@ -94,7 +94,7 @@ void handle_orientation(enum Orientation orientation) {
     // (and pray that our lord and savior vaxry won't change hyprctl output)
     system_fmt("while IFS=$'\n' read -r device ; do "
             "hyprctl keyword device:\"$device\":transform %d; "
-            "done <<< \"$(hyprctl devices | awk '/Touch Device at|Tablet at/ {getline;print $1}')\"",
+            "done <<< \"$(hyprctl devices | awk '/Touch Device at/ {getline;print $1}')\"",
             orientation);
 }
 


### PR DESCRIPTION
I noticed my Yoga C930 pen started acting up when rotated and found out that main.c line 97 grabbing Tablet as well reverses the rotation Hyprland does on it's own. Is this the case with every device?
I have
```
tablet {
    output=eDP-1
}
```
on my config but it seems to rotate fine using only Hyprland even without it