### PR TITLE
Fixed touchdevice not autorotating after hyprland update

### DIFF
--- a/main.c
+++ b/main.c
@@ -91,11 +91,9 @@ void handle_orientation(enum Orientation orientation) {
     system_fmt("hyprctl keyword monitor %s,transform,%d", output, orientation);
 
     // transform touch devices
-    // (and pray that our lord and savior vaxry won't change hyprctl output)
-    system_fmt("while IFS=$'\n' read -r device ; do "
-            "hyprctl keyword device:\"$device\":transform %d; "
-            "done <<< \"$(hyprctl devices | awk '/Touch Device at|Tablet at/ {getline;print $1}')\"",
-            orientation);
+    system_fmt("hyprctl keyword input:touchdevice:transform %d", orientation);
+    system_fmt("hyprctl keyword input:tablet:transform %d", orientation);
+
 }
 
 DBusMessage* request_orientation(DBusConnection* conn) {


### PR DESCRIPTION
### Overview:
This pull request fixes a small bug where after updating to hyprland v0.37.x, the autorotation of touchinput is not working after rotating monitor device with iio-hyprland.

### Problem:
After updating hyprland, the Touch Devices are not being rotated on my 2-in-1.
Executing iio-hyprland shows the following output:
```
ok
config option <device:wacom-hid-5215-pen:transform> does not exist.
config option <device:wacom-hid-5215-finger:transform> does not exist.
```

### Cause:
Now, hyprland's default behaviour is assigning the digitizer rotation value automatically when the monitor rotation changes. Thanks to this PR: https://github.com/hyprwm/Hyprland/pull/3544 
Therefore Hyprland's config for changing touchdevice rotation is changed in v0.37.0
Now to rotate touchdevice, the config entry looks like this (from hyprland wiki v0.37.0):
```
input {
    touchdevice {
        transform = 1
    }
}

```

### Changes Made:
- Added appropriate command based on new config changes instead of manually looping through all devices since, hyprland automatically does it now.


### Testing Done:
- Tested the fix on _Lenovo IdeaPad Flex 5 14ALC05_ and autorotation of touchdevice works correctly as intended.