### PR TITLE
Modified `hyprctl` call in `main.c`

### DIFF
--- a/main.c
+++ b/main.c
@@ -87,19 +87,7 @@ void handle_orientation(enum Orientation orientation) {
     if (orientation == Undefined)
         return;
 
-    // transform display
-    // system_fmt("hyprctl keyword monitor %s,transform,%d", output, orientation);
-
-    // transform touch devices
-    // (and pray that our lord and savior vaxry won't change hyprctl output)
-
-    /*
-    system_fmt("while IFS=$'\n' read -r device ; do "
-            "hyprctl keyword device:\"$device\":transform %d; "
-            "done <<< \"$(hyprctl devices | awk '/Touch Device at|Tablet at/ {getline;print $1}')\"",
-            orientation);
-    */
-
+    // transform display and touch devices with a hyprctl batch command
     system_fmt("hyprctl --batch \"keyword monitor %s,transform,%d ; keyword input:touchdevice:transform %d ; keyword input:tablet:transform %d\"", output, orientation, orientation, orientation);
 }
 

--- a/main.c
+++ b/main.c
@@ -88,14 +88,19 @@ void handle_orientation(enum Orientation orientation) {
         return;
 
     // transform display
-    system_fmt("hyprctl keyword monitor %s,transform,%d", output, orientation);
+    // system_fmt("hyprctl keyword monitor %s,transform,%d", output, orientation);
 
     // transform touch devices
     // (and pray that our lord and savior vaxry won't change hyprctl output)
+
+    /*
     system_fmt("while IFS=$'\n' read -r device ; do "
             "hyprctl keyword device:\"$device\":transform %d; "
             "done <<< \"$(hyprctl devices | awk '/Touch Device at|Tablet at/ {getline;print $1}')\"",
             orientation);
+    */
+
+    system_fmt("hyprctl --batch \"keyword monitor %s,transform,%d ; keyword input:touchdevice:transform %d ; keyword input:tablet:transform %d\"", output, orientation, orientation, orientation);
 }
 
 DBusMessage* request_orientation(DBusConnection* conn) {


### PR DESCRIPTION
Reasons:
* Bug fix: in the original, only my screen would transform, but not the touch devices (vaxry did change `hyprctl`). Now everything works.
* To make the `hyprctl` call more efficient by grouping multiple calls in one `batch` call. [See the 1st warning on this page](https://wiki.hyprland.org/Configuring/Using-hyprctl/) . You don't need to iterate over the output of `hyprctl devices` anymore.