### PR TITLE
feature: add `--left-master` and `--right-master` flags

### DIFF
--- a/main.c
+++ b/main.c
@@ -110,13 +110,13 @@ void handle_orientation(enum Orientation orientation) {
             system_fmt("hyprctl --batch \"keyword monitor %s,transform,%d ; keyword input:touchdevice:transform %d ; keyword input:tablet:transform %d ; keyword workspace m[%s], layoutopt:orientation:right\"", output, orientation, orientation, orientation, output);
         }
         else if (orientation == LeftUp) {
-            system_fmt("hyprctl --batch \"keyword monitor %s,transform,%d ; keyword input:touchdevice:transform %d ; keyword input:tablet:transform %d ; keyword workspace m[%s], layoutopt:orientation:top\"", output, orientation, orientation, orientation, output);
+            system_fmt("hyprctl --batch \"keyword monitor %s,transform,%d ; keyword input:touchdevice:transform %d ; keyword input:tablet:transform %d ; keyword workspace m[%s], layoutopt:orientation:bottom\"", output, orientation, orientation, orientation, output);
         }
         else if (orientation == BottomUp) {
             system_fmt("hyprctl --batch \"keyword monitor %s,transform,%d ; keyword input:touchdevice:transform %d ; keyword input:tablet:transform %d ; keyword workspace m[%s], layoutopt:orientation:right\"", output, orientation, orientation, orientation, output);
         }
         else { // This covers RightUp orientation
-            system_fmt("hyprctl --batch \"keyword monitor %s,transform,%d ; keyword input:touchdevice:transform %d ; keyword input:tablet:transform %d ; keyword workspace m[%s], layoutopt:orientation:top\"", output, orientation, orientation, orientation, output);
+            system_fmt("hyprctl --batch \"keyword monitor %s,transform,%d ; keyword input:touchdevice:transform %d ; keyword input:tablet:transform %d ; keyword workspace m[%s], layoutopt:orientation:bottom\"", output, orientation, orientation, orientation, output);
         }
     }
     else {


### PR DESCRIPTION
Adds a new flag `--rotate-master-layout` which, when passed in, rotates the master layout on the selected monitor so the master window is on the top when the screen is rotated vertically or on the left when the screen is horizontal. This commit also utilises batch commands as recommended in the hyprland documentation (see #20).

Possible issues:
- No error messages are given to the user
- This assumes that the user wants the master window to always be on the left side or on top. It will also undo any changes the user makes with a keybinding when the device is rotated again. Maybe a config file can be used?