### PR TITLE
Handle batches of messages from sensitive sensors

### DIFF
--- a/main.c
+++ b/main.c
@@ -197,7 +197,12 @@ void listen_orientation(DBusConnection* connection, const char* monitor_id) {
         if (msg != NULL) {
             if (dbus_message_is_signal(msg, "org.freedesktop.DBus.Properties",
                     "PropertiesChanged")) {
-                handle_orientation(parse_orientation_signal(msg), monitor_id);
+                if (parse_orientation_signal(msg) != Undefined) {
+                    // Handle batches of messages from sensitive sensors
+                    usleep(1000 * 300); // 300ms
+                    dbus_connection_flush(connection);
+                    init_orientation(connection, monitor_id);
+                }
             } else {
                 dbus_message_unref(msg);
                 break;


### PR DESCRIPTION
I was having issues with my screen rotating when it shouldn't or not ending up with the right orientation due to how iio-hyprland handles batches of messages. I don't know if this is generally applicable, but it's been very helpful for my device.