### PR TITLE
fixed jq not found in nixos flake

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -7,6 +7,7 @@
   dbus,
   pkg-config,
   jq,
+  makeWrapper
 }:
 stdenv.mkDerivation rec {
   pname = "iio-hyprland";
@@ -16,11 +17,20 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     pkg-config
-    dbus
     meson
     ninja
+    makeWrapper
+  ];
+
+  buildInputs = [
+    dbus
     jq
   ];
+
+  postInstall = ''
+    wrapProgram "$out/bin/iio-hyprland" \
+      --prefix PATH : "${jq}/bin"
+  '';
 
   meta = with lib; {
     description = "Listen iio-sensor-proxy and auto change Hyprland output orientation";

--- a/default.nix
+++ b/default.nix
@@ -6,6 +6,7 @@
   ninja,
   dbus,
   pkg-config,
+  jq,
 }:
 stdenv.mkDerivation rec {
   pname = "iio-hyprland";
@@ -18,6 +19,7 @@ stdenv.mkDerivation rec {
     dbus
     meson
     ninja
+    jq
   ];
 
   meta = with lib; {


### PR DESCRIPTION
******@nixos:~/ > iio-hyprland
sh: 行 1: jq: 未找到命令
fgets: Resource temporarily unavailable
error: cannot get monitor ID for eDP-1
dbus[48471]: Applications must not close shared connections - see dbus_connection_close() docs. This is a bug in the application.
  D-Bus not built with -rdynamic so unable to print a backtrace
zsh: IOT instruction (core dumped)  iio-hyprland